### PR TITLE
feat: add project excerpt to mobile via accordion

### DIFF
--- a/components/FeaturedProjects/ProjectCard.tsx
+++ b/components/FeaturedProjects/ProjectCard.tsx
@@ -7,6 +7,13 @@ import {
   CardFooter,
 } from '@/components/ui/card'
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '../ui/accordion'
+
 import ButtonLink from '../ui/button-link'
 import Icon from '../Icon'
 import Image from 'next/image'
@@ -34,10 +41,13 @@ export default function ProjectCard({ project }: ProjectCardProps) {
           ))}
         </div>
       </CardHeader>
-      <CardContent className="relative h-[220px]">
+      <CardContent className="relative h-[208px] md:h-[220px]">
+        {/* project image on desktop view */}
         <div className="absolute z-10 flex h-[200px] w-[320px] items-center justify-center rounded-md bg-secondary px-4 opacity-0 transition-all duration-300 ease-in-out group-hover/card:opacity-100">
           {project.excerpt}
         </div>
+
+        {/* project image */}
         <Image
           src={project.image}
           className="absolute z-20 rounded-md opacity-100 shadow-lg shadow-primary/20 transition-all duration-300 ease-in-out group-hover/card:opacity-0"
@@ -47,7 +57,20 @@ export default function ProjectCard({ project }: ProjectCardProps) {
           loading="lazy"
         />
       </CardContent>
-      <CardFooter>
+      <CardFooter className="flex flex-col md:flex-row">
+        {/* project excerpt on mobile view */}
+        <Accordion
+          type="single"
+          collapsible
+          className="mb-4 block w-full md:hidden"
+        >
+          <AccordionItem value="Description">
+            <AccordionTrigger className="text-xl text-primary">
+              Project Description
+            </AccordionTrigger>
+            <AccordionContent>{project.excerpt}</AccordionContent>
+          </AccordionItem>
+        </Accordion>
         <div className="flex w-full items-center gap-4">
           {project.liveSiteUrl && (
             <ButtonLink


### PR DESCRIPTION
Mobile view did not have the project excerpt.  The two options were 1) Display in a collapsable accordion or 2) always have it displayed below the project image.

The problem with option 2 is the project card becomes super long on mobile view so I went with approach 1 using shadcn/ui accordion component.